### PR TITLE
chore: upgrade dependency `cli-table` to version 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ surrealdb-migrate = { version = "0.1", path = "surrealdb-migrate" }
 # 3rd party dependencies
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
-cli-table = { version = "0.4", default-features = false, features = ["derive"] }
+cli-table = { version = "0.5", default-features = false, features = ["derive"] }
 color-eyre = "0.6"
 config = { version = "0.15", default-features = false, features = ["toml"] }
 crc32fast = "1"


### PR DESCRIPTION
upgraded version of dependency `cli-table` to version 0.5