### PR TITLE
chore: switch to the `asserting` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tokio = { version = "1", features = ["macros"] }
 # dev-dependencies
 anyhow = "1"
 assert_fs = "1"
+asserting = "0.7"
 assertor = "0.0.3"
 dotenvy = "0.15"
 proptest = { version = "1", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ tokio = { version = "1", features = ["macros"] }
 anyhow = "1"
 assert_fs = "1"
 asserting = "0.7"
-assertor = "0.0.3"
 dotenvy = "0.15"
 proptest = { version = "1", default-features = false, features = ["std"] }
 snapbox = "0.6"

--- a/database-migration-files/Cargo.toml
+++ b/database-migration-files/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["database"]
 database-migration.workspace = true
 
 [dev-dependencies]
-assertor.workspace = true
+asserting.workspace = true
 assert_fs.workspace = true
 database-migration = { workspace = true, features = ["test-dsl"] }
 version-sync.workspace = true

--- a/database-migration-files/src/tests.rs
+++ b/database-migration-files/src/tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use assert_fs::TempDir;
-use assertor::*;
+use asserting::prelude::*;
 use database_migration::definition::MigrationFilenameStrategy;
 use database_migration::error::{DefinitionError, Error};
 use database_migration::migration::{Migration, MigrationKind};
@@ -204,7 +204,7 @@ fn read_script_content_for_basic_migrations() {
         .read_script_content_for_migrations(migrations)
         .expect("failed to read script content");
 
-    assert_that!(script_contents).contains_exactly_in_order(vec![
+    assert_that!(script_contents).contains_exactly([
         ScriptContent {
             key: key("20250103_140520"),
             kind: MigrationKind::Up,
@@ -313,20 +313,16 @@ fn create_migration_file_for_new_migration() {
 
     let migration = migration_files.create_new_migration(new_migration);
 
-    assert_that!(migration).is_equal_to(Ok(Migration {
-        key: key("20250115_201642"),
-        title: "create some table".into(),
-        kind: MigrationKind::Up,
-        script_path: migrations_folder.join("20250115_201642_create_some_table.up.surql"),
-    }));
-
-    assert_that!(
-        migration
-            .expect("failed to create new migration file")
-            .script_path
-            .exists()
-    )
-    .is_true();
+    assert_that!(migration)
+        .ok()
+        .is_equal_to(Migration {
+            key: key("20250115_201642"),
+            title: "create some table".into(),
+            kind: MigrationKind::Up,
+            script_path: migrations_folder.join("20250115_201642_create_some_table.up.surql"),
+        })
+        .extracting(|mig| mig.script_path.exists())
+        .is_true();
 }
 
 #[test]
@@ -345,20 +341,16 @@ fn create_migration_file_for_new_migration_with_empty_title() {
 
     let migration = migration_files.create_new_migration(new_migration);
 
-    assert_that!(migration).is_equal_to(Ok(Migration {
-        key: key("20250115_201642"),
-        title: "".into(),
-        kind: MigrationKind::Up,
-        script_path: migrations_folder.join("20250115_201642.up.surql"),
-    }));
-
-    assert_that!(
-        migration
-            .expect("failed to create new migration file")
-            .script_path
-            .exists()
-    )
-    .is_true();
+    assert_that!(migration)
+        .ok()
+        .is_equal_to(Migration {
+            key: key("20250115_201642"),
+            title: "".into(),
+            kind: MigrationKind::Up,
+            script_path: migrations_folder.join("20250115_201642.up.surql"),
+        })
+        .extracting(|mig| mig.script_path.exists())
+        .is_true();
 }
 
 #[test]
@@ -377,20 +369,16 @@ fn create_migration_file_for_down_migration() {
 
     let migration = migration_files.create_new_migration(new_migration);
 
-    assert_that!(migration).is_equal_to(Ok(Migration {
-        key: key("20250115_201642"),
-        title: "create some table".into(),
-        kind: MigrationKind::Down,
-        script_path: migrations_folder.join("20250115_201642_create_some_table.down.surql"),
-    }));
-
-    assert_that!(
-        migration
-            .expect("failed to create new migration file")
-            .script_path
-            .exists()
-    )
-    .is_true();
+    assert_that!(migration)
+        .ok()
+        .is_equal_to(Migration {
+            key: key("20250115_201642"),
+            title: "create some table".into(),
+            kind: MigrationKind::Down,
+            script_path: migrations_folder.join("20250115_201642_create_some_table.down.surql"),
+        })
+        .extracting(|mig| mig.script_path.exists())
+        .is_true();
 }
 
 #[test]
@@ -409,20 +397,16 @@ fn create_migration_file_for_down_migration_with_empty_title() {
 
     let migration = migration_files.create_new_migration(new_migration);
 
-    assert_that!(migration).is_equal_to(Ok(Migration {
-        key: key("20250115_201642"),
-        title: "".into(),
-        kind: MigrationKind::Down,
-        script_path: migrations_folder.join("20250115_201642.down.surql"),
-    }));
-
-    assert_that!(
-        migration
-            .expect("failed to create new migration file")
-            .script_path
-            .exists()
-    )
-    .is_true();
+    assert_that!(migration)
+        .ok()
+        .is_equal_to(Migration {
+            key: key("20250115_201642"),
+            title: "".into(),
+            kind: MigrationKind::Down,
+            script_path: migrations_folder.join("20250115_201642.down.surql"),
+        })
+        .extracting(|mig| mig.script_path.exists())
+        .is_true();
 }
 
 #[test]
@@ -441,20 +425,16 @@ fn create_migration_file_for_new_migration_file_already_existing() {
 
     let existing_migration = migration_files.create_new_migration(new_migration.clone());
 
-    assert_that!(existing_migration).is_equal_to(Ok(Migration {
-        key: key("20250115_201642"),
-        title: "create some table".into(),
-        kind: MigrationKind::Up,
-        script_path: migrations_folder.join("20250115_201642_create_some_table.up.surql"),
-    }));
-
-    assert_that!(
-        existing_migration
-            .expect("existing file not created")
-            .script_path
-            .exists()
-    )
-    .is_true();
+    assert_that!(existing_migration)
+        .ok()
+        .is_equal_to(Migration {
+            key: key("20250115_201642"),
+            title: "create some table".into(),
+            kind: MigrationKind::Up,
+            script_path: migrations_folder.join("20250115_201642_create_some_table.up.surql"),
+        })
+        .extracting(|mig| mig.script_path.exists())
+        .is_true();
 
     let result = migration_files.create_new_migration(new_migration);
 
@@ -471,7 +451,7 @@ fn create_migration_file_for_new_migration_folder_does_not_exist() {
 
     let new_migration = NewMigration {
         key: key("20250115_201642"),
-        title: "create some table".to_string(),
+        title: "create some table".into(),
         kind: MigrationKind::Up,
     };
 

--- a/database-migration-files/tests/version_numbers.rs
+++ b/database-migration-files/tests/version_numbers.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 mod dummy_extern_uses {
     use assert_fs as _;
-    use assertor as _;
+    use asserting as _;
     use database_migration as _;
     use database_migration_files as _;
 }

--- a/database-migration/Cargo.toml
+++ b/database-migration/Cargo.toml
@@ -34,7 +34,7 @@ thiserror.workspace = true
 proptest = { workspace = true, optional = true, default-features = false, features = ["std"] }
 
 [dev-dependencies]
-assertor.workspace = true
+asserting.workspace = true
 proptest = { workspace = true, default-features = true }
 version-sync.workspace = true
 

--- a/database-migration/src/action/tests.rs
+++ b/database-migration/src/action/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::checksum::Checksum;
 use crate::migration::MigrationKind;
 use crate::test_dsl::{applicable_migrations, executed_migrations, key};
-use assertor::*;
+use asserting::prelude::*;
 use chrono::DateTime;
 use std::path::Path;
 use std::time::Duration;
@@ -16,42 +16,42 @@ mod checks {
     fn checks_with_checksum_only() {
         let checks = Checks::only(Check::Checksum);
 
-        assert_that!(checks.iter()).contains_exactly([Check::Checksum].into_iter());
+        assert_that!(checks).contains_exactly_in_any_order([Check::Checksum]);
     }
 
     #[test]
     fn checks_with_order_only() {
         let checks = Checks::only(Check::Order);
 
-        assert_that!(checks.iter()).contains_exactly([Check::Order].into_iter());
+        assert_that!(checks).contains_exactly_in_any_order([Check::Order]);
     }
 
     #[test]
     fn a_check_can_be_converted_to_checks() {
         let checks = Checks::from(Check::Checksum);
 
-        assert_that!(checks.iter()).contains_exactly([Check::Checksum].into_iter());
+        assert_that!(checks).contains_exactly_in_any_order([Check::Checksum]);
     }
 
     #[test]
     fn none_checks_contains_no_check() {
         let checks = Checks::none();
 
-        assert_that!(checks.iter()).is_empty();
+        assert_that!(checks.iter().next()).is_none();
     }
 
     #[test]
     fn all_checks_contains_all_check_variants() {
         let checks = Checks::all();
 
-        assert_that!(checks.iter()).contains_exactly([Check::Checksum, Check::Order].into_iter());
+        assert_that!(checks).contains_exactly_in_any_order([Check::Checksum, Check::Order]);
     }
 
     #[test]
     fn check_variants_can_be_added() {
         let checks = Check::Checksum + Check::Order;
 
-        assert_that!(checks.iter()).contains_exactly([Check::Checksum, Check::Order].into_iter());
+        assert_that!(checks).contains_exactly_in_any_order([Check::Checksum, Check::Order]);
     }
 
     #[test]
@@ -60,8 +60,7 @@ mod checks {
 
         checks += Check::Checksum;
 
-        assert_that!(checks.into_iter())
-            .contains_exactly([Check::Checksum, Check::Order].into_iter());
+        assert_that!(checks).contains_exactly_in_any_order([Check::Checksum, Check::Order]);
     }
 }
 
@@ -124,7 +123,7 @@ mod verify {
 
         let problematic = verify.list_out_of_order(&defined, &executed);
 
-        assert_that!(problematic).contains_exactly_in_order(vec![ProblematicMigration {
+        assert_that!(problematic).contains_exactly_in_any_order(vec![ProblematicMigration {
             key: key("20250109_125900"),
             kind: MigrationKind::Up,
             script_path: Path::new("migrations/20250109_125900_create_name_set_two.surql").into(),
@@ -190,7 +189,7 @@ mod verify {
 
         let problematic = verify.list_out_of_order(&defined, &executed);
 
-        assert_that!(problematic).contains_exactly_in_order(vec![
+        assert_that!(problematic).contains_exactly([
             ProblematicMigration {
                 key: key("20250109_115959"),
                 kind: MigrationKind::Up,
@@ -480,7 +479,7 @@ mod verify {
 
         let problematic = verify.list_changed_after_execution(&defined, &executed);
 
-        assert_that!(problematic).contains_exactly_in_order(vec![ProblematicMigration {
+        assert_that!(problematic).contains_exactly(vec![ProblematicMigration {
             key: key("20250109_125900"),
             kind: MigrationKind::Up,
             script_path: Path::new("migrations/20250109_125900_create_name_set_one.surql").into(),
@@ -613,7 +612,7 @@ mod verify {
 
         let problematic = verify.list_changed_after_execution(&defined, &executed);
 
-        assert_that!(problematic).contains_exactly_in_order(vec![ProblematicMigration {
+        assert_that!(problematic).contains_exactly(vec![ProblematicMigration {
             key: key("20250109_125900"),
             kind: MigrationKind::Up,
             script_path: Path::new("migrations/20250109_125900_create_name_set_one.surql").into(),
@@ -725,7 +724,7 @@ mod verify {
 
         let problematic = verify.list_changed_after_execution(&defined, &executed);
 
-        assert_that!(problematic).contains_exactly_in_order(vec![ProblematicMigration {
+        assert_that!(problematic).contains_exactly(vec![ProblematicMigration {
             key: key("20250110_090059"),
             kind: MigrationKind::Up,
             script_path: Path::new("migrations/20250110_090059_create_name_set_two.surql").into(),
@@ -755,15 +754,14 @@ mod migrate {
         let migrate = Migrate::default();
         let applicable = migrate.list_migrations_to_apply(&defined, &executed);
 
-        assert_that!(applicable.iter()).contains_exactly_in_order(
-            applicable_migrations([ApplicableMigration {
+        assert_that!(applicable).contains_exactly_in_any_order(applicable_migrations([
+            ApplicableMigration {
                 key: key("20250109_125900"),
                 kind: MigrationKind::Up,
                 script_content: r#"LET $data = ["J. Jonah Jameson", "James Earl Jones"];"#.into(),
                 checksum: Checksum(0x_08C11ABD),
-            }])
-            .iter(),
-        );
+            },
+        ]));
     }
 
     #[test]
@@ -797,15 +795,14 @@ mod migrate {
         let migrate = Migrate::default();
         let applicable = migrate.list_migrations_to_apply(&defined, &executed);
 
-        assert_that!(applicable.iter()).contains_exactly_in_order(
-            applicable_migrations([ApplicableMigration {
+        assert_that!(applicable).contains_exactly_in_any_order(applicable_migrations([
+            ApplicableMigration {
                 key: key("20250110_090059"),
                 kind: MigrationKind::Up,
                 script_content: r#"LET $data = ["Alice Sulton", "Tamara Jackson"];"#.into(),
                 checksum: Checksum(0x_DD081E07),
-            }])
-            .iter(),
-        );
+            },
+        ]));
     }
 
     #[test]
@@ -839,24 +836,20 @@ mod migrate {
         let migrate = Migrate::default();
         let applicable = migrate.list_migrations_to_apply(&defined, &executed);
 
-        assert_that!(applicable.iter()).contains_exactly_in_order(
-            applicable_migrations([
-                ApplicableMigration {
-                    key: key("20250109_125900"),
-                    kind: MigrationKind::Baseline,
-                    script_content: r#"LET $data = ["J. Jonah Jameson", "James Earl Jones"];"#
-                        .into(),
-                    checksum: Checksum(0x_08C11ABD),
-                },
-                ApplicableMigration {
-                    key: key("20250110_090059"),
-                    kind: MigrationKind::Up,
-                    script_content: r#"LET $data = ["Simon Says", "Lucy May"];"#.into(),
-                    checksum: Checksum(0x_AA0137FA),
-                },
-            ])
-            .iter(),
-        );
+        assert_that!(applicable).contains_exactly_in_any_order(applicable_migrations([
+            ApplicableMigration {
+                key: key("20250109_125900"),
+                kind: MigrationKind::Baseline,
+                script_content: r#"LET $data = ["J. Jonah Jameson", "James Earl Jones"];"#.into(),
+                checksum: Checksum(0x_08C11ABD),
+            },
+            ApplicableMigration {
+                key: key("20250110_090059"),
+                kind: MigrationKind::Up,
+                script_content: r#"LET $data = ["Simon Says", "Lucy May"];"#.into(),
+                checksum: Checksum(0x_AA0137FA),
+            },
+        ]));
     }
 }
 
@@ -885,15 +878,14 @@ mod revert {
         let revert = Revert::default();
         let applicable = revert.list_migrations_to_apply(&defined, &executed);
 
-        assert_that!(applicable.iter()).contains_exactly_in_order(
-            applicable_migrations([ApplicableMigration {
+        assert_that!(applicable).contains_exactly_in_any_order(applicable_migrations([
+            ApplicableMigration {
                 key: key("20250109_125900"),
                 kind: MigrationKind::Down,
                 script_content: r#"LET $data = ["J. Jonah Jameson", "James Earl Jones"];"#.into(),
                 checksum: Checksum(0x_08C11ABD),
-            }])
-            .iter(),
-        );
+            },
+        ]));
     }
 
     #[test]
@@ -927,15 +919,14 @@ mod revert {
         let revert = Revert::default();
         let applicable = revert.list_migrations_to_apply(&defined, &executed);
 
-        assert_that!(applicable.iter()).contains_exactly_in_order(
-            applicable_migrations([ApplicableMigration {
+        assert_that!(applicable).contains_exactly_in_any_order(applicable_migrations([
+            ApplicableMigration {
                 key: key("20250109_125900"),
                 kind: MigrationKind::Down,
                 script_content: r#"LET $data = ["J. Jonah Jameson", "James Earl Jones"];"#.into(),
                 checksum: Checksum(0x_08C11ABD),
-            }])
-            .iter(),
-        );
+            },
+        ]));
     }
 
     #[test]
@@ -994,14 +985,13 @@ mod revert {
         let revert = Revert::default();
         let applicable = revert.list_migrations_to_apply(&defined, &executed);
 
-        assert_that!(applicable.iter()).contains_exactly_in_order(
-            applicable_migrations([ApplicableMigration {
+        assert_that!(applicable).contains_exactly_in_any_order(applicable_migrations([
+            ApplicableMigration {
                 key: key("20250109_130000"),
                 kind: MigrationKind::Down,
                 script_content: r#"LET $data = ["Alice Sulton", "Tamara Jackson"];"#.into(),
                 checksum: Checksum(0x_DD081E07),
-            }])
-            .iter(),
-        );
+            },
+        ]));
     }
 }

--- a/database-migration/src/definition/tests.rs
+++ b/database-migration/src/definition/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::migration::MigrationKind;
 use crate::proptest_support::{any_direction, any_key, any_title};
 use crate::test_dsl::key;
-use assertor::*;
+use asserting::prelude::*;
 use proptest::prelude::*;
 use std::sync::LazyLock;
 
@@ -17,7 +17,7 @@ mod str {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_ok(Migration {
+        assert_that!(migration).ok().is_equal_to(Migration {
             key: key("20250103_140830"),
             title: "define some table".into(),
             kind: MigrationKind::Up,
@@ -31,7 +31,7 @@ mod str {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_ok(Migration {
+        assert_that!(migration).ok().is_equal_to(Migration {
             key: key("20250103_140830"),
             title: "define some table".into(),
             kind: MigrationKind::Up,
@@ -45,7 +45,7 @@ mod str {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_ok(Migration {
+        assert_that!(migration).ok().is_equal_to(Migration {
             key: key("20250103_140830"),
             title: "define some table".into(),
             kind: MigrationKind::Up,
@@ -59,7 +59,7 @@ mod str {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_ok(Migration {
+        assert_that!(migration).ok().is_equal_to(Migration {
             key: key("20250103_140830"),
             title: "define some table".into(),
             kind: MigrationKind::Down,
@@ -77,7 +77,7 @@ mod string {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_ok(Migration {
+        assert_that!(migration).ok().is_equal_to(Migration {
             key: key("20250103_140830"),
             title: "define some table".into(),
             kind: MigrationKind::Up,
@@ -96,7 +96,7 @@ mod os_str {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_ok(Migration {
+        assert_that!(migration).ok().is_equal_to(Migration {
             key: key("20250103_140830"),
             title: "define some table".into(),
             kind: MigrationKind::Up,
@@ -115,7 +115,7 @@ mod path {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_ok(Migration {
+        assert_that!(migration).ok().is_equal_to(Migration {
             key: key("20250103_140830"),
             title: "define some table".into(),
             kind: MigrationKind::Up,
@@ -129,7 +129,7 @@ mod path {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_ok(Migration {
+        assert_that!(migration).ok().is_equal_to(Migration {
             key: key("20250103_140830"),
             title: "define some table".into(),
             kind: MigrationKind::Up,
@@ -143,7 +143,7 @@ mod path {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_ok(Migration {
+        assert_that!(migration).ok().is_equal_to(Migration {
             key: key("20250103_140830"),
             title: "define some table".into(),
             kind: MigrationKind::Down,
@@ -157,7 +157,7 @@ mod path {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_ok(Migration {
+        assert_that!(migration).ok().is_equal_to(Migration {
             key: key("20250103_140830"),
             title: "define some table".into(),
             kind: MigrationKind::Up,
@@ -171,7 +171,7 @@ mod path {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_ok(Migration {
+        assert_that!(migration).ok().is_equal_to(Migration {
             key: key("20250103_140830"),
             title: "".into(),
             kind: MigrationKind::Up,
@@ -186,7 +186,8 @@ mod path {
         let migration = path.parse_migration();
 
         assert_that!(migration)
-            .has_err(DefinitionError::InvalidDate("input is out of range".into()));
+            .err()
+            .is_equal_to(DefinitionError::InvalidDate("input is out of range".into()));
     }
 
     #[test]
@@ -195,9 +196,11 @@ mod path {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_err(DefinitionError::InvalidTime(
-            "input contains invalid characters".into(),
-        ));
+        assert_that!(migration)
+            .err()
+            .is_equal_to(DefinitionError::InvalidTime(
+                "input contains invalid characters".into(),
+            ));
     }
 
     #[test]
@@ -206,7 +209,9 @@ mod path {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_err(DefinitionError::AmbiguousDirection);
+        assert_that!(migration)
+            .err()
+            .is_equal_to(DefinitionError::AmbiguousDirection);
     }
 
     #[test]
@@ -215,7 +220,9 @@ mod path {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_err(DefinitionError::InvalidFilename);
+        assert_that!(migration)
+            .err()
+            .is_equal_to(DefinitionError::InvalidFilename);
     }
 
     #[test]
@@ -224,7 +231,9 @@ mod path {
 
         let migration = path.parse_migration();
 
-        assert_that!(migration).has_err(DefinitionError::InvalidFilename);
+        assert_that!(migration)
+            .err()
+            .is_equal_to(DefinitionError::InvalidFilename);
     }
 }
 

--- a/database-migration/src/migration/tests.rs
+++ b/database-migration/src/migration/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::proptest_support::any_migration_kind;
-use assertor::*;
+use asserting::prelude::*;
 use proptest::prelude::*;
 
 mod migration_kind {

--- a/database-migration/tests/version_numbers.rs
+++ b/database-migration/tests/version_numbers.rs
@@ -2,7 +2,7 @@
 // Rust issue [#95513](https://github.com/rust-lang/rust/issues/95513) is fixed
 #[cfg(test)]
 mod dummy_extern_uses {
-    use assertor as _;
+    use asserting as _;
     use chrono as _;
     use crc32fast as _;
     use database_migration as _;

--- a/surrealdb-migrate-cli/Cargo.toml
+++ b/surrealdb-migrate-cli/Cargo.toml
@@ -45,7 +45,7 @@ tokio.workspace = true
 database-migration = { workspace = true, features = ["test-dsl"] }
 surrealdb-migrate-db-client.workspace = true
 assert_fs.workspace = true
-assertor.workspace = true
+asserting.workspace = true
 dotenvy.workspace = true
 snapbox.workspace = true
 testcontainers-modules = { workspace = true, features = ["surrealdb"] }

--- a/surrealdb-migrate-cli/src/list_cmd.rs
+++ b/surrealdb-migrate-cli/src/list_cmd.rs
@@ -83,7 +83,7 @@ const fn display_ordering(mig1: MigrationKind, mig2: MigrationKind) -> Ordering 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assertor::*;
+    use asserting::prelude::*;
 
     mod display_ordering {
         use super::*;

--- a/surrealdb-migrate-cli/src/main.rs
+++ b/surrealdb-migrate-cli/src/main.rs
@@ -140,7 +140,7 @@ fn logger_config() -> simplelog::Config {
 #[cfg(test)]
 mod dummy_extern_uses {
     use assert_fs as _;
-    use assertor as _;
+    use asserting as _;
     use database_migration as _;
     use dotenvy as _;
     use snapbox as _;

--- a/surrealdb-migrate-cli/tests/create_cmd.rs
+++ b/surrealdb-migrate-cli/tests/create_cmd.rs
@@ -3,7 +3,7 @@ mod fixtures;
 use crate::fixtures::files::list_filenames_in_dir;
 use crate::fixtures::surmig;
 use assert_fs::TempDir;
-use assertor::*;
+use asserting::prelude::*;
 
 #[test]
 fn create_migration_with_current_date_and_time_and_no_title() {
@@ -86,9 +86,7 @@ fn create_migration_with_given_key_and_a_given_title() {
     assert_that!(migrations_folder.exists()).is_true();
     assert_that!(migrations_folder.is_dir()).is_true();
     let mig_files = list_filenames_in_dir(&migrations_folder).collect::<Vec<_>>();
-    assert_that!(mig_files).contains_exactly(vec![
-        "20250126_120033_add_some_more_quotes.up.surql".to_string(),
-    ]);
+    assert_that!(mig_files).contains_exactly(["20250126_120033_add_some_more_quotes.up.surql"]);
 }
 
 #[test]
@@ -144,8 +142,8 @@ fn create_migration_including_down_migration() {
     assert_that!(migrations_folder.exists()).is_true();
     assert_that!(migrations_folder.is_dir()).is_true();
     let mig_files = list_filenames_in_dir(&migrations_folder).collect::<Vec<_>>();
-    assert_that!(mig_files).contains_exactly(vec![
-        "20250126_120033_add_some_more_quotes.up.surql".to_string(),
-        "20250126_120033_add_some_more_quotes.down.surql".to_string(),
+    assert_that!(mig_files).contains_exactly_in_any_order([
+        "20250126_120033_add_some_more_quotes.up.surql",
+        "20250126_120033_add_some_more_quotes.down.surql",
     ]);
 }

--- a/surrealdb-migrate-cli/tests/fixtures/mod.rs
+++ b/surrealdb-migrate-cli/tests/fixtures/mod.rs
@@ -17,7 +17,7 @@ pub fn surmig() -> Command {
 #[cfg(test)]
 mod dummy_extern_uses {
     use assert_fs as _;
-    use assertor as _;
+    use asserting as _;
     use chrono as _;
     use clap as _;
     use cli_table as _;

--- a/surrealdb-migrate-cli/tests/verify_cmd.rs
+++ b/surrealdb-migrate-cli/tests/verify_cmd.rs
@@ -3,7 +3,7 @@ use crate::fixtures::db::{
 };
 use crate::fixtures::surmig;
 use assert_fs::TempDir;
-use assertor::*;
+use asserting::prelude::*;
 use database_migration::test_dsl::{datetime, key};
 use std::fs;
 use std::fs::read_to_string;

--- a/surrealdb-migrate-config/Cargo.toml
+++ b/surrealdb-migrate-config/Cargo.toml
@@ -23,7 +23,7 @@ config.workspace = true
 serde.workspace = true
 
 [dev-dependencies]
-assertor.workspace = true
+asserting.workspace = true
 
 [lints]
 workspace = true

--- a/surrealdb-migrate-config/src/tests.rs
+++ b/surrealdb-migrate-config/src/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use assertor::*;
+use asserting::prelude::*;
 use database_migration::config::{
     DEFAULT_EXCLUDED_FILES, DbAuthLevel, DbClientConfig, RunnerConfig,
 };

--- a/surrealdb-migrate-db-client/Cargo.toml
+++ b/surrealdb-migrate-db-client/Cargo.toml
@@ -33,7 +33,7 @@ surrealdb.workspace = true
 
 [dev-dependencies]
 database-migration = { workspace = true, features = ["test-dsl"] }
-assertor.workspace = true
+asserting.workspace = true
 dotenvy.workspace = true
 testcontainers-modules = { workspace = true, features = ["surrealdb"] }
 tokio.workspace = true

--- a/surrealdb-migrate-db-client/src/tests.rs
+++ b/surrealdb-migrate-db-client/src/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use assertor::*;
+use asserting::prelude::*;
 
 mod extract_table_definition_version {
     use super::*;

--- a/surrealdb-migrate-db-client/tests/connect_to_database.rs
+++ b/surrealdb-migrate-db-client/tests/connect_to_database.rs
@@ -5,7 +5,7 @@ use crate::fixtures::db::{
     start_surrealdb_testcontainer,
 };
 use crate::fixtures::load_environment_variables;
-use assertor::*;
+use asserting::prelude::*;
 use database_migration::config::DbAuthLevel;
 use fixtures::db::initialize_database;
 use surrealdb_migrate_db_client::connect_to_database;

--- a/surrealdb-migrate-db-client/tests/migrations_table.rs
+++ b/surrealdb-migrate-db-client/tests/migrations_table.rs
@@ -6,7 +6,7 @@ use crate::fixtures::db::{
     client_config_for_testcontainer, connect_to_test_database_as_database_user, get_db_tables_info,
     start_surrealdb_testcontainer,
 };
-use assertor::*;
+use asserting::prelude::*;
 use chrono::DateTime;
 use database_migration::checksum::{Checksum, hash_migration_script};
 use database_migration::config::{DEFAULT_MIGRATIONS_TABLE, MIGRATION_KEY_FORMAT_STR};
@@ -51,7 +51,7 @@ async fn define_migrations_table_in_empty_database() {
 
     let db_tables_info = get_db_tables_info(&db).await;
 
-    assert_that!(db_tables_info).contains_key("my_migrations".to_string());
+    assert_that!(db_tables_info).contains_key("my_migrations");
 }
 
 #[tokio::test]

--- a/surrealdb-migrate/Cargo.toml
+++ b/surrealdb-migrate/Cargo.toml
@@ -47,7 +47,7 @@ log.workspace = true
 database-migration = { workspace = true, features = ["test-dsl"] }
 anyhow.workspace = true
 assert_fs.workspace = true
-assertor.workspace = true
+asserting.workspace = true
 color-eyre.workspace = true
 dotenvy.workspace = true
 testcontainers-modules = { workspace = true, features = ["surrealdb"] }

--- a/surrealdb-migrate/src/runner/tests.rs
+++ b/surrealdb-migrate/src/runner/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use assertor::*;
+use asserting::prelude::*;
 
 mod migration_runner {
     use super::*;
@@ -45,7 +45,7 @@ mod migration_runner {
             .list_defined_migrations(MigrationKind::is_forward)
             .expect("failed to list defined migrations");
 
-        assert_that!(defined_migrations).contains_exactly_in_order(vec![
+        assert_that!(defined_migrations).contains_exactly([
             Migration {
                 key: key("20250103_140520"),
                 title: "define quote table".into(),

--- a/surrealdb-migrate/tests/fixtures/mod.rs
+++ b/surrealdb-migrate/tests/fixtures/mod.rs
@@ -11,7 +11,7 @@ pub fn load_environment_variables() {
 mod dummy_extern_uses {
     use anyhow as _;
     use assert_fs as _;
-    use assertor as _;
+    use asserting as _;
     use chrono as _;
     use color_eyre as _;
     use database_migration as _;

--- a/surrealdb-migrate/tests/migration_runner.rs
+++ b/surrealdb-migrate/tests/migration_runner.rs
@@ -5,13 +5,12 @@ use crate::fixtures::db::{
     start_surrealdb_testcontainer,
 };
 use assert_fs::TempDir;
-use assertor::*;
+use asserting::prelude::*;
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fs;
 use std::fs::File;
 use std::io::read_to_string;
-use std::iter::once;
 use std::path::Path;
 use std::time::Duration;
 use surrealdb_migrate::checksum::hash_migration_script;
@@ -98,7 +97,7 @@ async fn list_applied_migrations_from_a_database_with_two_migrations_applied() {
         .await
         .expect("failed to query list of applied migrations");
 
-    assert_that!(applied_migrations).contains_exactly_in_order(vec![
+    assert_that!(applied_migrations).contains_exactly([
         Execution {
             key: key("20250103_140520"),
             applied_rank: 1,
@@ -134,8 +133,7 @@ async fn run_migrations_on_empty_db() {
 
     let tables_info = get_db_tables_info(&db).await;
 
-    assert_that!(tables_info.keys())
-        .contains_exactly(["migrations".to_string(), "quote".to_string()].iter());
+    assert_that!(tables_info.keys()).contains_exactly_in_any_order(["migrations", "quote"]);
 
     let quotes: Vec<HashMap<String, String>> = db
         .query("SELECT text FROM quote ORDER BY text")
@@ -144,14 +142,13 @@ async fn run_migrations_on_empty_db() {
         .take(0)
         .expect("did not get expected query result");
 
-    assert_that!(quotes.iter().map(|row| &row["text"])).contains_exactly_in_order(
+    assert_that!(quotes.iter().map(|row| &row["text"])).contains_exactly_in_any_order(
         [
-            "Behind every great man is a woman rolling her eyes. - Jim Carrey".to_string(),
-            "If you want a guarantee, buy a toaster. - Clint Eastwood".to_string(),
-            "It takes considerable knowledge just to realize the extent of your own ignorance. - Thomas Sowell".to_string(),
-            "don't seek happiness - create it".to_string(),
-        ]
-        .iter(),
+            "Behind every great man is a woman rolling her eyes. - Jim Carrey",
+            "If you want a guarantee, buy a toaster. - Clint Eastwood",
+            "It takes considerable knowledge just to realize the extent of your own ignorance. - Thomas Sowell",
+            "don't seek happiness - create it",
+        ],
     );
 }
 
@@ -170,7 +167,7 @@ async fn run_migrations_on_fully_migrated_db() {
     let tables_info = get_db_tables_info(&db).await;
 
     assert_that!(tables_info.keys())
-        .contains_exactly([DEFAULT_MIGRATIONS_TABLE.to_string(), "quote".to_string()].iter());
+        .contains_exactly_in_any_order([DEFAULT_MIGRATIONS_TABLE, "quote"]);
 
     let migrated = runner.migrate(&db).await.expect("failed to run migrations");
 
@@ -178,8 +175,7 @@ async fn run_migrations_on_fully_migrated_db() {
 
     let tables_info = get_db_tables_info(&db).await;
 
-    assert_that!(tables_info.keys())
-        .contains_exactly(["migrations".to_string(), "quote".to_string()].iter());
+    assert_that!(tables_info.keys()).contains_exactly_in_any_order(["migrations", "quote"]);
 
     let quotes: Vec<HashMap<String, String>> = db
         .query("SELECT text FROM quote ORDER BY text")
@@ -188,14 +184,13 @@ async fn run_migrations_on_fully_migrated_db() {
         .take(0)
         .expect("did not get expected query result");
 
-    assert_that!(quotes.iter().map(|row| &row["text"])).contains_exactly_in_order(
+    assert_that!(quotes.iter().map(|row| &row["text"])).contains_exactly_in_any_order(
         [
-            "Behind every great man is a woman rolling her eyes. - Jim Carrey".to_string(),
-            "If you want a guarantee, buy a toaster. - Clint Eastwood".to_string(),
-            "It takes considerable knowledge just to realize the extent of your own ignorance. - Thomas Sowell".to_string(),
-            "don't seek happiness - create it".to_string(),
-        ]
-        .iter(),
+            "Behind every great man is a woman rolling her eyes. - Jim Carrey",
+            "If you want a guarantee, buy a toaster. - Clint Eastwood",
+            "It takes considerable knowledge just to realize the extent of your own ignorance. - Thomas Sowell",
+            "don't seek happiness - create it",
+        ],
     );
 }
 
@@ -218,8 +213,7 @@ async fn migrate_an_empty_db_up_to_migration_20250103_140520() {
 
     let tables_info = get_db_tables_info(&db).await;
 
-    assert_that!(tables_info.keys())
-        .contains_exactly(["migrations".to_string(), "quote".to_string()].iter());
+    assert_that!(tables_info.keys()).contains_exactly_in_any_order(["migrations", "quote"]);
 
     let quotes: Vec<HashMap<String, String>> = db
         .query("SELECT text FROM quote ORDER BY text")
@@ -228,7 +222,7 @@ async fn migrate_an_empty_db_up_to_migration_20250103_140520() {
         .take(0)
         .expect("did not get expected query result");
 
-    assert_that!(quotes.iter().map(|row| &row["text"])).is_empty();
+    assert_that!(quotes.iter().map(|row| &row["text"]).next()).is_none();
 }
 
 #[tokio::test]
@@ -246,7 +240,7 @@ async fn revert_migrations_on_fully_migrated_db() {
     let tables_info = get_db_tables_info(&db).await;
 
     assert_that!(tables_info.keys())
-        .contains_exactly([DEFAULT_MIGRATIONS_TABLE.to_string(), "quote".to_string()].iter());
+        .contains_exactly_in_any_order([DEFAULT_MIGRATIONS_TABLE, "quote"]);
 
     let reverted = runner
         .revert(&db)
@@ -257,7 +251,7 @@ async fn revert_migrations_on_fully_migrated_db() {
 
     let tables_info = get_db_tables_info(&db).await;
 
-    assert_that!(tables_info.keys()).contains_exactly(once(&DEFAULT_MIGRATIONS_TABLE.to_string()));
+    assert_that!(tables_info.keys()).contains_exactly_in_any_order([DEFAULT_MIGRATIONS_TABLE]);
 }
 
 #[tokio::test]
@@ -272,7 +266,7 @@ async fn revert_migrations_on_empty_db() {
 
     let tables_info = get_db_tables_info(&db).await;
 
-    assert_that!(tables_info.keys()).is_empty();
+    assert_that!(tables_info.keys().next()).is_none();
 
     let reverted = runner
         .revert(&db)
@@ -283,7 +277,7 @@ async fn revert_migrations_on_empty_db() {
 
     let tables_info = get_db_tables_info(&db).await;
 
-    assert_that!(tables_info.keys()).is_empty();
+    assert_that!(tables_info.keys().next()).is_none();
 }
 
 #[tokio::test]
@@ -301,7 +295,7 @@ async fn revert_a_fully_migrated_db_down_to_migration_20250103_140520() {
     let tables_info = get_db_tables_info(&db).await;
 
     assert_that!(tables_info.keys())
-        .contains_exactly([DEFAULT_MIGRATIONS_TABLE.to_string(), "quote".to_string()].iter());
+        .contains_exactly_in_any_order([DEFAULT_MIGRATIONS_TABLE, "quote"]);
 
     let reverted = runner
         .revert_to(key("20250103_140520"), &db)
@@ -313,7 +307,7 @@ async fn revert_a_fully_migrated_db_down_to_migration_20250103_140520() {
     let tables_info = get_db_tables_info(&db).await;
 
     assert_that!(tables_info.keys())
-        .contains_exactly([DEFAULT_MIGRATIONS_TABLE.to_string(), "quote".to_string()].iter());
+        .contains_exactly_in_any_order([DEFAULT_MIGRATIONS_TABLE, "quote"]);
 }
 
 #[tokio::test]
@@ -417,7 +411,7 @@ async fn verify_fully_migrated_database_one_migration_out_of_order() {
     let result = runner.verify(&db).await;
 
     if let Ok(Verified::FoundProblems(problems)) = result {
-        assert_that!(problems[0].problem).is_equal_to(Problem::OutOfOrder {
+        assert_that!(&problems[0].problem).is_equal_to(&Problem::OutOfOrder {
             last_applied_key: key("20250103_141521"),
         });
         assert_that!(problems[0].key).is_equal_to(key("20250103_141030"));
@@ -491,7 +485,7 @@ async fn verify_fully_migrated_database_one_migration_changed() {
     let result = runner.verify(&db).await;
 
     if let Ok(Verified::FoundProblems(problems)) = result {
-        assert_that!(problems[0].problem).is_equal_to(Problem::ChecksumMismatch {
+        assert_that!(&problems[0].problem).is_equal_to(&Problem::ChecksumMismatch {
             definition_checksum,
             execution_checksum,
         });
@@ -573,7 +567,7 @@ async fn verify_fully_migrated_database_one_migration_changed_and_one_out_of_ord
     let result = runner.verify(&db).await;
 
     if let Ok(Verified::FoundProblems(problems)) = result {
-        assert_that!(problems[0].problem).is_equal_to(Problem::OutOfOrder {
+        assert_that!(&problems[0].problem).is_equal_to(&Problem::OutOfOrder {
             last_applied_key: key("20250103_141521"),
         });
         assert_that!(problems[0].key).is_equal_to(key("20250103_141030"));
@@ -581,7 +575,7 @@ async fn verify_fully_migrated_database_one_migration_changed_and_one_out_of_ord
         assert_that!(problems[0].script_path.file_name().and_then(OsStr::to_str))
             .is_equal_to(Some("20250103_141030_out_of_order_migration.surql"));
 
-        assert_that!(problems[1].problem).is_equal_to(Problem::ChecksumMismatch {
+        assert_that!(&problems[1].problem).is_equal_to(&Problem::ChecksumMismatch {
             definition_checksum,
             execution_checksum,
         });

--- a/surrealdb-migrate/tests/version_numbers.rs
+++ b/surrealdb-migrate/tests/version_numbers.rs
@@ -4,7 +4,7 @@
 mod dummy_extern_uses {
     use anyhow as _;
     use assert_fs as _;
-    use assertor as _;
+    use asserting as _;
     use chrono as _;
     use color_eyre as _;
     use database_migration as _;


### PR DESCRIPTION
The `asserting` crate provides fluent assertions for tests. It has some minor advantages over other fluent assertion crates.

Replaced the dependency on the `assertor` crate by the `asserting` crate as well as fixed and optimized the assertions in the tests